### PR TITLE
Better scoped rslt variable

### DIFF
--- a/lib/outdatedlog.js
+++ b/lib/outdatedlog.js
@@ -7,7 +7,6 @@ var cmp = require('semver-compare');
 var async = require('async');
 var chalk = require('chalk');
 
-var rslt = {};
 var showMax = false;
 
 function worker(packages, unwanted, global) {
@@ -25,15 +24,14 @@ function worker(packages, unwanted, global) {
 			if (err) {
 				throw err;
 			}
-			rslt = {};
 			// For each npm outdated module
-			async.forEachOf(data, workerChangelog, prettyData);
+			async.reduce(data, {}, workerChangelog, prettyData);
 
 		});
 	});
 }
 
-function workerChangelog(value, key, callback) {
+function workerChangelog(rslt, value, callback) {
 	// Generate changelog
 	changelog.generate(value[1])
 		.then(function(data) {
@@ -49,7 +47,7 @@ function workerChangelog(value, key, callback) {
 			data.versions = tmpArray;
 			// Generate terminal output
 			rslt[value[1]] = changelog.terminal(data);
-			callback();
+			callback(null, rslt);
 		})
 		.catch(function(err) {
 			if (typeof err === 'string') {
@@ -58,13 +56,13 @@ function workerChangelog(value, key, callback) {
 			else {
 				throw err;
 			}
-			callback();
+			callback(null, rslt);
 		})
 		.done();
 
 }
 
-function prettyData(err) {
+function prettyData(err, rslt) {
 	if (err) {
 		throw err;
 	}


### PR DESCRIPTION
This change removes the `rslt` variable defined globally (and later reset to an empty object). This is achieved by defining the `rslt` object in a more appropriate scope and passing it directly to the functions that require it.